### PR TITLE
fix: randKecamatan return as id not value

### DIFF
--- a/src/NIK.php
+++ b/src/NIK.php
@@ -107,7 +107,9 @@ final class NIK
 
     private function randKecamatan(): int
     {
-        return (int) array_rand($this->dbs[$this->provinsi][$this->kabupaten_kota]);
+        $rand = array_rand($this->dbs[$this->provinsi][$this->kabupaten_kota]);
+
+        return $this->dbs[$this->provinsi][$this->kabupaten_kota][$rand];
     }
 
     public function randAll(): self


### PR DESCRIPTION
Rand provinsi using native array rand because id in key. Rand kebupten/kota using native array rand because id in key. But rand kecamatan id position in the value. So need extra step to get current id. 